### PR TITLE
Removed heading for the houses logos.

### DIFF
--- a/hogwarts.css
+++ b/hogwarts.css
@@ -1,339 +1,347 @@
 @import url("https://fonts.googleapis.com/css2?family=Baloo+2:wght@500&display=swap");
-@import url('https://fonts.googleapis.com/css2?family=Crimson+Text&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Crimson+Text&display=swap");
 
-@import url('https://fonts.googleapis.com/css2?family=Oswald:wght@200&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Oswald:wght@200&display=swap");
 
-
-@font-face {font-family: "AuldMagick Bold"; src: url("https://db.onlinewebfonts.com/t/8da4e7bc1e0eb9534a2ee26db6d521ce.eot"); src: url("//db.onlinewebfonts.com/t/8da4e7bc1e0eb9534a2ee26db6d521ce.eot?#iefix") format("embedded-opentype"), url("//db.onlinewebfonts.com/t/8da4e7bc1e0eb9534a2ee26db6d521ce.woff2") format("woff2"), url("//db.onlinewebfonts.com/t/8da4e7bc1e0eb9534a2ee26db6d521ce.woff") format("woff"), url("//db.onlinewebfonts.com/t/8da4e7bc1e0eb9534a2ee26db6d521ce.ttf") format("truetype"), url("//db.onlinewebfonts.com/t/8da4e7bc1e0eb9534a2ee26db6d521ce.svg#AuldMagick Bold") format("svg"); } 
 @font-face {
-  font-family: 'Magic School One';
-  src: url(/house_page_template/magic-school.one.ttf);
+	font-family: "AuldMagick Bold";
+	src: url("https://db.onlinewebfonts.com/t/8da4e7bc1e0eb9534a2ee26db6d521ce.eot");
+	src: url("//db.onlinewebfonts.com/t/8da4e7bc1e0eb9534a2ee26db6d521ce.eot?#iefix")
+			format("embedded-opentype"),
+		url("//db.onlinewebfonts.com/t/8da4e7bc1e0eb9534a2ee26db6d521ce.woff2")
+			format("woff2"),
+		url("//db.onlinewebfonts.com/t/8da4e7bc1e0eb9534a2ee26db6d521ce.woff")
+			format("woff"),
+		url("//db.onlinewebfonts.com/t/8da4e7bc1e0eb9534a2ee26db6d521ce.ttf")
+			format("truetype"),
+		url("//db.onlinewebfonts.com/t/8da4e7bc1e0eb9534a2ee26db6d521ce.svg#AuldMagick Bold")
+			format("svg");
+}
+@font-face {
+	font-family: "Magic School One";
+	src: url(/house_page_template/magic-school.one.ttf);
 }
 body {
-  margin: 0;
-  padding: 0;
-  background-color: rgb(235, 229, 270);
-  font-family: Arial, Helvetica, sans-serif;
+	margin: 0;
+	padding: 0;
+	background-color: rgb(235, 229, 270);
+	font-family: Arial, Helvetica, sans-serif;
 }
 
 header {
-  width: 100%;
-  background-color: black;
-  background-image: radial-gradient(
-      white,
-      rgba(255, 255, 255, 0.2) 2px,
-      transparent 40px
-    ),
-    radial-gradient(white, rgba(255, 255, 255, 0.15) 1px, transparent 30px),
-    radial-gradient(white, rgba(255, 255, 255, 0.1) 2px, transparent 40px),
-    radial-gradient(
-      rgba(255, 255, 255, 0.4),
-      rgba(255, 255, 255, 0.1) 2px,
-      transparent 30px
-    );
-  background-size: 550px 550px, 350px 350px, 250px 250px, 150px 150px;
-  background-position: 0 0, 40px 60px, 130px 270px, 70px 100px;
-  /* border-bottom: 1px solid #133783; */
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: 0.6rem 0;
-  color: white;
+	width: 100%;
+	background-color: black;
+	background-image: radial-gradient(
+			white,
+			rgba(255, 255, 255, 0.2) 2px,
+			transparent 40px
+		),
+		radial-gradient(white, rgba(255, 255, 255, 0.15) 1px, transparent 30px),
+		radial-gradient(white, rgba(255, 255, 255, 0.1) 2px, transparent 40px),
+		radial-gradient(
+			rgba(255, 255, 255, 0.4),
+			rgba(255, 255, 255, 0.1) 2px,
+			transparent 30px
+		);
+	background-size: 550px 550px, 350px 350px, 250px 250px, 150px 150px;
+	background-position: 0 0, 40px 60px, 130px 270px, 70px 100px;
+	/* border-bottom: 1px solid #133783; */
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	padding: 0.6rem 0;
+	color: white;
 }
 
 #hog {
-  font-family: 'Magic School One';
-  font-weight: bold;
-  font-size: 8vw;
-  margin-bottom: 2rem;
-  
+	font-family: "Magic School One";
+	font-weight: bold;
+	font-size: 8vw;
+	margin-bottom: 2rem;
 }
 #hog1 {
-  font-family: 'Magic School One';
-  /*font-weight: bold;*/
-  font-size: 3vw;
+	font-family: "Magic School One";
+	/*font-weight: bold;*/
+	font-size: 3vw;
 }
-
 
 #dr {
-  font-style: italic;
-  font-size: 2vw;
-  font-family: sans-serif;
-  margin-top: 0px;
+	font-style: italic;
+	font-size: 2vw;
+	font-family: sans-serif;
+	margin-top: 0px;
 }
 main {
-  display: flex;
+	display: flex;
 }
 .section {
-  flex-grow: 1;
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  background: url(./images/hall.jpg);
-  background-size: cover;
-  background-attachment: fixed;
+	flex-grow: 1;
+	width: 100%;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	background: url(./images/hall.jpg);
+	background-size: cover;
+	background-attachment: fixed;
 }
 
 #heading {
-
-  font-size: 2vw;
-  font-style: italic;
-  color: rgb(248, 247, 247);
-  background-color: rgba(0, 0, 0, 0.4);
-  padding: 5px;
-  border-radius: 5px;
+	font-size: 2vw;
+	font-style: italic;
+	color: rgb(248, 247, 247);
+	background-color: rgba(0, 0, 0, 0.4);
+	padding: 5px;
+	border-radius: 5px;
 }
 #img {
-  width: 20vw;
-  height: 20vw;
-  border-radius: 50%;
-  border: 1vw solid;
-  border-color: wheat;
-  box-shadow: 0 20px 20px 20px #0c1445;
+	width: 20vw;
+	height: 20vw;
+	border-radius: 50%;
+	border: 1vw solid;
+	border-color: wheat;
+	box-shadow: 0 20px 20px 20px #0c1445;
 }
-#home h1{
-  font-size: 4.1vw;
+#home h1 {
+	font-size: 4.1vw;
 }
 main {
-  display: flex;
-  width:100;
-  
+	display: flex;
+	width: 100;
 }
 .sec {
-
-  flex-grow: 1;
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  background-color: rgb(36, 36, 36);
-  color: white;
+	flex-grow: 1;
+	width: 100%;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	background-color: rgb(36, 36, 36);
+	color: white;
 }
 
 .sec2 {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
-  background-color: rgb(36, 36, 36);
-  color: white;
-  width: 100%;
-  padding: 0px 0px 45px 15vw;
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	align-items: center;
+	background-color: rgb(36, 36, 36);
+	color: white;
+	width: 100%;
+	padding: 0px 0px 45px 15vw;
 }
 
 #para {
-  font-family:'Crimson Text', cursive;
-  /*font-family:'Baloo 2',cursive;*/
-  font-style: italic;
-  width: 70%;
-  font-size: 1.5rem;
-
+	font-family: "Crimson Text", cursive;
+	/*font-family:'Baloo 2',cursive;*/
+	font-style: italic;
+	width: 70%;
+	font-size: 1.5rem;
 }
 
 #h3 {
-  font-family:'Crimson Text',cursive;
-  font-style: italic;
-  border-style: solid;
-  font-size: 1.5rem;
-  margin: 0 5%;
+	font-family: "Crimson Text", cursive;
+	font-style: italic;
+	border-style: solid;
+	font-size: 1.5rem;
+	margin: 0 5%;
 }
 
 #ig1 {
-  border-color: red;
-  box-shadow: 0 20px 20px 20px gold;
+	border-color: red;
+	box-shadow: 0 20px 20px 20px gold;
 }
 #ig2 {
-  border-color: blue;
-  box-shadow: 0 20px 20px 20px whitesmoke;
+	border-color: blue;
+	box-shadow: 0 20px 20px 20px whitesmoke;
 }
 #ig3 {
-  border-color: yellow;
-  box-shadow: 0 20px 20px 20px rgb(128, 116, 98);
+	border-color: yellow;
+	box-shadow: 0 20px 20px 20px rgb(128, 116, 98);
 }
 #ig4 {
-  border-color: green;
-  box-shadow: 0 20px 20px 20px silver;
+	border-color: green;
+	box-shadow: 0 20px 20px 20px silver;
 }
 
 .ig {
-  width: 20vw;
-  height: 20vw;
-  border-radius: 50%;
-  border: 1vw solid;
-  margin: 2.5rem;
+	width: 20vw;
+	height: 20vw;
+	border-radius: 50%;
+	border: 1vw solid;
+	margin: 2.5rem;
 }
 
 h1 {
-  font-size: 5.4rem;
-  color: #fff;
-  box-shadow: 0px 2px 15px 2px var(#fffdfd);
-  background-color: rgba(0, 0, 0, 0.5);
-  background:none;
-  border-radius: 6px;
-  margin-bottom: 5rem;
-  padding: 5px;
-  opacity:1;
+	font-size: 5.4rem;
+	color: #fff;
+	box-shadow: 0px 2px 15px 2px var(#fffdfd);
+	background-color: rgba(0, 0, 0, 0.5);
+	background: none;
+	border-radius: 6px;
+	margin-bottom: 5rem;
+	padding: 5px;
+	opacity: 1;
 }
 
 .container {
-  width: 100vw;
-  height: 100vh;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  max-width: 80rem;
-  margin: 0 auto;
-  padding: 2rem;
+	width: 100vw;
+	height: 100vh;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	max-width: 80rem;
+	margin: 0 auto;
+	padding: 2rem;
 }
 
 .flex-column {
-  display: flex;
-  flex-direction: column;
+	display: flex;
+	flex-direction: column;
 }
 
 .flex-center {
-  justify-content: center;
-  align-items: center;
+	justify-content: center;
+	align-items: center;
 }
 
 .justify-center {
-  justify-content: center;
+	justify-content: center;
 }
 
 .text-center {
-  text-align: center;
+	text-align: center;
 }
 
 .hidden {
-  display: none;
+	display: none;
 }
 
 .btn {
-  font-size: 2vw;
-  padding: 5% 0;
-  width: 30vw;
-  text-align: center;
-  margin-bottom: 1rem;
-  text-decoration: none;
-  color: rgb(28, 26, 26);
-  background: linear-gradient(
-    90deg,
-    rgb(18, 92, 255) 0%,
-    rgb(0, 102, 255) 100%
-  );
-  border-radius: 4px;
+	font-size: 2vw;
+	padding: 5% 0;
+	width: 30vw;
+	text-align: center;
+	margin-bottom: 1rem;
+	text-decoration: none;
+	color: rgb(28, 26, 26);
+	background: linear-gradient(
+		90deg,
+		rgb(18, 92, 255) 0%,
+		rgb(0, 102, 255) 100%
+	);
+	border-radius: 4px;
 }
-.fas{
-  font-size: 2vw;
+.fas {
+	font-size: 2vw;
 }
 
 .btn:hover {
-  cursor: pointer;
-  box-shadow: 0 0.4rem 1.4rem 0 rgba(8, 114, 244, 0.6);
-  transition: transform 150ms;
-  transform: scale(1.03);
+	cursor: pointer;
+	box-shadow: 0 0.4rem 1.4rem 0 rgba(8, 114, 244, 0.6);
+	transition: transform 150ms;
+	transform: scale(1.03);
 }
 
 .btn[disabled]:hover {
-  cursor: not-allowed;
-  box-shadow: none;
-  transform: none;
+	cursor: not-allowed;
+	box-shadow: none;
+	transform: none;
 }
 
 #highscore-btn {
-  background: linear-gradient(
-    90deg,
-    rgb(255, 247, 9) 0%,
-    rgb(240, 221, 6) 100%
-  );
+	background: linear-gradient(
+		90deg,
+		rgb(255, 247, 9) 0%,
+		rgb(240, 221, 6) 100%
+	);
 }
 
 #highscore-btn:hover {
-  box-shadow: 0 0.4rem 1.4rem 0 rgba(255, 255, 0, 0.5);
+	box-shadow: 0 0.4rem 1.4rem 0 rgba(255, 255, 0, 0.5);
 }
 
 .fa-crown {
-  font-size: 2vw;
-  margin-left: 1rem;
+	font-size: 2vw;
+	margin-left: 1rem;
 }
 
 footer {
-  background-color: #172269;
-  padding: 5%;
-  text-align: center;
+	background-color: #172269;
+	padding: 5%;
+	text-align: center;
 }
 
 footer p {
-  margin: -21px 0px;
-  font-weight: bold;
-  font-size: 25px;
+	margin: -21px 0px;
+	font-weight: bold;
+	font-size: 25px;
 }
 
 footer p a {
-  color: #fff;
+	color: #fff;
 }
 
 footer p a:hover {
-  color: #1e7352;
+	color: #1e7352;
 }
 
 .fact {
-  font-family: "Baloo 2", cursive;
-  color: white;
-  font-size: 2vw;
-  text-align: center;
-  font-weight: 500;
-  margin-top: 70px;
-  margin-bottom: 0px;
-  background: rgba(0, 0, 0, 0.6);
-  width: fit-content;
-  cursor: pointer;
+	font-family: "Baloo 2", cursive;
+	color: white;
+	font-size: 2vw;
+	text-align: center;
+	font-weight: 500;
+	margin-top: 70px;
+	margin-bottom: 0px;
+	background: rgba(0, 0, 0, 0.6);
+	width: fit-content;
+	cursor: pointer;
 }
 
 .fact:hover {
-  color: rgba(255, 255, 255, 0.9);
+	color: rgba(255, 255, 255, 0.9);
 }
 
-@media (max-width:620px){
-  #hog,#home h1{
-    font-size: 5vw;
-  }
-  #hog1{
-    font-size: 2vw;
-  }
-  #dr,#heading, .fact{
-    font-size: 3vw;
-  }
-  .btn{
-    
-    width: 30vw;
-    padding: 5% 20%;
-  }
-  #para, #h3{
-    
-    font-size: 1rem;
-  }
-  footer{
-    padding: 10%;
-  }
+@media (max-width: 620px) {
+	#hog,
+	#home h1 {
+		font-size: 5vw;
+	}
+	#hog1 {
+		font-size: 2vw;
+	}
+	#dr,
+	#heading,
+	.fact {
+		font-size: 3vw;
+	}
+	.btn {
+		width: 30vw;
+		padding: 5% 20%;
+	}
+	#para,
+	#h3 {
+		font-size: 1rem;
+	}
+	footer {
+		padding: 10%;
+	}
 }
 #myBtn {
-  position: fixed; 
-  bottom: 20px; 
-  right: 30px; 
-  z-index: 99; 
-  border: none; 
-  outline: none; 
-  background-color: rgb(134, 34, 34); 
-  color: white;
-  cursor: pointer; 
-  padding: 15px;
-  border-radius: 10px; 
-  font-size: 20px; 
-  border-radius: 30px;
+	position: fixed;
+	bottom: 20px;
+	right: 30px;
+	z-index: 99;
+	border: none;
+	outline: none;
+	background-color: rgb(134, 34, 34);
+	color: white;
+	cursor: pointer;
+	padding: 15px;
+	border-radius: 10px;
+	font-size: 20px;
+	border-radius: 30px;
 }
 
 #myBtn:hover {
-  background-color: rgb(61, 2, 2);
+	background-color: rgb(61, 2, 2);
 }

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>Hogwarts</title>
     <link rel="stylesheet" href="hogwarts.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
-    
+
     <script src="prefixfree.min.js"></script>
     <script src="./index.js"></script>
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
@@ -74,23 +74,25 @@
         <div class="sec2">
             <div>
                 <a href="./Gryffindor/Gryffindor.html" target="_blank">
-                <img class="ig" id="ig1"
-                    src="https://i.pinimg.com/originals/1a/64/49/1a6449ba53c49b816d56c5abbbb1d8dc.jpg" alt="Gryffindor"></a>
+                    <img class="ig" id="ig1"
+                        src="https://i.pinimg.com/originals/1a/64/49/1a6449ba53c49b816d56c5abbbb1d8dc.jpg"
+                        alt="Gryffindor"></a>
                 <br>
                 <a href="./Ravenclaw/ravenclaw.html" target="_blank">
-                <img class="ig" id="ig2"
-                    src="https://www.redwolf.in/image/catalog/artwork-Images/mens/ravenclaw-crest-t-shirt-artwork.jpg"
-                    alt="Ravenclaw"></a>
+                    <img class="ig" id="ig2"
+                        src="https://www.redwolf.in/image/catalog/artwork-Images/mens/ravenclaw-crest-t-shirt-artwork.jpg"
+                        alt="Ravenclaw"></a>
             </div>
             <div>
-               <a href="./Hufflepuff/Hufflepuff.html" target="_blank">
-                <img class="ig" id="ig3"
-                    src="https://www.redwolf.in/image/catalog/artwork-Images/mens/hufflepuff-crest-t-shirt-artwork.jpg"
-                    alt="Hufflepuff"></a>
+                <a href="./Hufflepuff/Hufflepuff.html" target="_blank">
+                    <img class="ig" id="ig3"
+                        src="https://www.redwolf.in/image/catalog/artwork-Images/mens/hufflepuff-crest-t-shirt-artwork.jpg"
+                        alt="Hufflepuff"></a>
                 <br>
                 <a href="./Slytherin/slytherin.html" target="_blank">
-                <img class="ig" id="ig4"
-                    src="https://i.pinimg.com/originals/de/d8/7e/ded87e4b3dad3327988511af87724206.jpg" alt="Slytherin"></a>
+                    <img class="ig" id="ig4"
+                        src="https://i.pinimg.com/originals/de/d8/7e/ded87e4b3dad3327988511af87724206.jpg"
+                        alt="Slytherin"></a>
             </div>
             <div>
                 <br>


### PR DESCRIPTION
Fixes issue #67 
Following changes were made:

- I have removed the heading for the houses logo in the website. 
- I have also modified the logos so that they redirect to their house pages. 
- Also added margin of ```2.5rem``` all around to the logos to ensure proper spacing between them.

This is preview of what the website looks like after modification:
![Screenshot from 2021-10-16 18-59-15](https://user-images.githubusercontent.com/70108561/137589411-a1196236-f259-4f97-aa07-7af1beb6fe1f.png)
